### PR TITLE
adds android automatic verification of app links

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,7 @@
           <category android:name="android.intent.category.BROWSABLE" />
           <data android:scheme="$URL_SCHEME" />
         </intent-filter>
-        <intent-filter>
+        <intent-filter android:autoVerify="true">
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
As described in https://developer.android.com/training/app-links/index.html this change should resolve #12 

> To enable link handling verification for your app, set the android:autoVerify attribute to true on at least one of the web URI intent filters in your app manifest, as shown in the following manifest code snippet:
> 
> <activity ...>
> 
> ```
> <intent-filter android:autoVerify="true">
>     <action android:name="android.intent.action.VIEW" />
>     <category android:name="android.intent.category.DEFAULT" />
>     <category android:name="android.intent.category.BROWSABLE" />
>     <data android:scheme="http" android:host="www.android.com" />
>     <data android:scheme="https" android:host="www.android.com" />
> </intent-filter>
> ```
> 
> </activity>
> When the android:autoVerify attribute is present, installing your app causes the system to attempt to verify all hosts associated with the web URIs in all of your app's intent filters. The system treats your app as the default handler for the specified URI pattern only if it successfully verifies all app link patterns declared in your manifest.
