### PR TITLE
Bump plugin version to 1.0.12 to match package

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="ionic-plugin-deeplinks"
-    version="1.0.8">
+    version="1.0.12">
     <name>Ionic Deeplink Plugin</name>
     <description>Ionic Deeplink Plugin</description>
     <license>MIT</license>


### PR DESCRIPTION
Hi there!

I was installing the latest version of this plugin (1.0.12) but Cordova seemed to be installing 1.0.8 instead. It took me a while until I discovered that Cordova uses the version defined in `plugin.xml` and it was actually installing the right version.

This PR just fixes the plugin version to match the package, assuming that you can re-publish it as 1.0.12.

Thanks!
