### PR TITLE
Bump plugin version to 1.0.13

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="ionic-plugin-deeplinks"
-    version="1.0.12">
+    version="1.0.13">
     <name>Ionic Deeplink Plugin</name>
     <description>Ionic Deeplink Plugin</description>
     <license>MIT</license>


### PR DESCRIPTION
Just bumping the `plugin.xml` version to match `package.json`.

Can you also publish this on NPM as 1.0.13? (latest is 1.0.12)